### PR TITLE
解决当单元格内容为'\'时的错误

### DIFF
--- a/download.py
+++ b/download.py
@@ -107,6 +107,6 @@ def read_sheet(url:string, sheet, opendoc_params, cookie_data:user_data):
 
 def read_callback(text):
     content = re.search(r"clientVarsCallback\(\"(.+)\"\)", text).group(1)
+    content = content.replace(r'\\', '\\')
     content = content.replace("&#34;", "\"")
-    content = content.replace(r'\\"', r"\\'")
     return json.loads(content)


### PR DESCRIPTION
当单元格内容为"\"时json的值为"\\\\", 此时会替换掉末尾的\"导致出错